### PR TITLE
Implement roll-table and probability-table syntax

### DIFF
--- a/build
+++ b/build
@@ -18,6 +18,7 @@ import jinja2
 import json
 import markdown
 import os
+import re
 import sys
 import xml.etree.ElementTree as ET
 import yaml
@@ -78,11 +79,128 @@ class GlossaryLinkExtension(markdown.extensions.Extension):
         )
 
 
+class ProbabilityTableProcessor(markdown.blockprocessors.BlockProcessor):
+    RE_START = r"!!!probability-table\n"
+
+    def test(self, parent, block):
+        return re.match(self.RE_START, block)
+
+    def run(self, parent, blocks):
+        entries = [
+            [entry.strip() for entry in line.strip().split(",")]
+            for line in re.sub(self.RE_START, "", blocks[0]).splitlines()
+            if line.strip()
+        ]
+
+        scale = 100
+        for entry in entries:
+            _, *entryPs = entry
+            for p in entryPs:
+                fp = float(p)
+                while fp * scale > 100:
+                    scale -= 1
+
+        table = self.mkEl(parent, "table", class_="probability-table")
+
+        thead = self.mkEl(table, "thead")
+        theadTr = self.mkEl(thead, "tr")
+        self.mkEl(theadTr, "th", class_="num", text="#")
+        for i in range(len(entries[0]) - 1):
+            self.mkEl(theadTr, "th", class_="num", text="%")
+            self.mkEl(theadTr, "th")
+
+        tbody = self.mkEl(table, "tbody")
+        for entry in entries:
+            entryN, *entryPs = entry
+            tr = self.mkEl(tbody, "tr")
+            self.mkEl(tr, "th", class_="num", text=entryN)
+            for p in entryPs:
+                self.mkEl(tr, "td", class_="num", text=f"{float(p):.2f}%")
+                td = self.mkEl(tr, "td")
+                self.mkEl(td, "div", class_="bar", text="&nbsp;").set(
+                    "style", f"width:calc({scale}*{p}%)"
+                )
+
+        blocks.pop(0)
+
+    def mkEl(self, parent, ty, text=None, class_=None):
+        el = ET.SubElement(parent, ty)
+        if class_:
+            el.set("class", class_)
+        if text:
+            el.text = text
+        return el
+
+
+class ProbabilityTableExtension(markdown.extensions.Extension):
+    def extendMarkdown(self, md):
+        md.parser.blockprocessors.register(
+            ProbabilityTableProcessor(md.parser),
+            "probability-table",
+            175,
+        )
+
+
+class RollTableProcessor(markdown.blockprocessors.BlockProcessor):
+    RE_START = r"!!!roll-table\n"
+
+    def test(self, parent, block):
+        return re.match(self.RE_START, block)
+
+    def run(self, parent, blocks):
+        title, *rows = [
+            line.strip()
+            for line in re.sub(self.RE_START, "", blocks[0]).splitlines()
+            if line.strip()
+        ]
+        entries = [[entry.strip() for entry in row.split(",", 1)] for row in rows]
+
+        table = self.mkEl(parent, "table", class_="roll-table")
+
+        thead = self.mkEl(table, "thead")
+        theadTr = self.mkEl(thead, "tr")
+        self.mkEl(theadTr, "th", class_="num", text="#")
+        for i in range(len(entries[0]) - 1):
+            self.mkEl(theadTr, "th", text=title)
+
+        tbody = self.mkEl(table, "tbody")
+        for entry in entries:
+            entryN, entryT = entry
+            tr = self.mkEl(tbody, "tr")
+            self.mkEl(tr, "th", class_="num", text=entryN)
+            self.mkEl(tr, "td", text=entryT)
+
+        blocks.pop(0)
+
+    def mkEl(self, parent, ty, text=None, class_=None):
+        el = ET.SubElement(parent, ty)
+        if class_:
+            el.set("class", class_)
+        if text:
+            el.text = text
+        return el
+
+
+class RollTableExtension(markdown.extensions.Extension):
+    def extendMarkdown(self, md):
+        md.parser.blockprocessors.register(
+            RollTableProcessor(md.parser),
+            "roll-table",
+            175,
+        )
+
+
 def do_markdown(text):
     return markdown.markdown(
         text,
         output_format="html5",
-        extensions=["admonition", "smarty", GlossaryLinkExtension()],
+        extensions=[
+            "admonition",
+            "smarty",
+            GlossaryLinkExtension(),
+            ProbabilityTableExtension(),
+            RollTableExtension(),
+        ],
     )
 
 

--- a/hashed-static/style.css
+++ b/hashed-static/style.css
@@ -8,6 +8,9 @@
     --border-admonition: #730b0b;
     --main-title-fg: #ffffff;
     --main-title-bg: #730b0b;
+    --thead-fg: #ffffff;
+    --thead-bg: #730b0b;
+    --table-bar-fg: #555555;
 }
 
 * {
@@ -142,7 +145,7 @@ p {
     padding-left: 20px;
 }
 
-.markdown p, .markdown li {
+.markdown p, .markdown li, .markdown table {
     margin-bottom: 16px;
 }
 
@@ -165,6 +168,49 @@ p {
 
 .markdown code {
     font-family: "Alegreya Sans SC", monospace;
+}
+
+.markdown table {
+    border-left: 1px solid var(--border);
+    border-right: 1px solid var(--border);
+    border-collapse: collapse;
+}
+
+.markdown thead {
+    background-color: var(--thead-bg);
+    color: var(--thead-fg);
+}
+
+.markdown thead a {
+    color: var(--thead-fg) !important;
+}
+
+.markdown th, .markdown td {
+    padding: 8px;
+    vertical-align: top;
+}
+
+.markdown tbody td, .markdown tbody th {
+    border-bottom: 1px solid var(--border);
+}
+
+.markdown .num {
+    width: 5%;
+    text-align: right;
+}
+
+.markdown .roll-table {
+    width: 80%;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.markdown .probability-table {
+    width: 100%;
+}
+
+.markdown .bar {
+    background-color: var(--table-bar-fg);
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
A roll table is a two-column table:

    !!!roll-table
    <title>
    <n>,<markdown description>
    ...

A probability table is an at-least-two column table:

    !!!probability-table
    <n>,<probability>,...

Which is rendered with a bar chart after each column of probabilities.
The bars are scaled to the largest integer multiple which fits, across
the whole table.  This is because a bar of, say, 10% width in a fairly
narrow column isn't very easy to read.