### PR TITLE
Add an optional "header image" to posts

### DIFF
--- a/_templates/post.html
+++ b/_templates/post.html
@@ -1,5 +1,9 @@
 {% extends "_base.html" %}
 {% block main %}
+  {% if header_image %}
+    <img src="{{ header_image }}" alt="{{ post.title }}"{% if post.header_image_title is defined %} title="{{ post.header_image_title }}"{% endif %} class="post-header">
+  {% endif %}
+
   <div class="markdown">
     {{ post.body | safe }}
   </div>

--- a/build
+++ b/build
@@ -135,14 +135,18 @@ for fname in os.listdir("hashed-static"):
     file_util.copy_file(fpath, os.path.join(OUT_DIR, HASHED_LINKS[fname]))
 
 
+def find_file_by_slug(directory, slug, default=None):
+    for ext in ["png", "jpg"]:
+        fname = f"{slug}.{ext}"
+        if os.path.isfile(os.path.join("static", directory, fname)):
+            return f"{directory}/{fname}"
+    return default
+
+
 def render(link, template, **metadata):
     slug = link.split("/")[-1].split(".")[0]
-    if os.path.isfile(os.path.join("static", "twitter-cards", slug + ".png")):
-        twitter_card = f"twitter-cards/{slug}.png"
-    elif os.path.isfile(os.path.join("static", "twitter-cards", slug + ".jpg")):
-        twitter_card = f"twitter-cards/{slug}.jpg"
-    else:
-        twitter_card = "twitter-card.png"
+    twitter_card = find_file_by_slug("twitter-cards", slug, default="twitter-card.jpg")
+    header_image = find_file_by_slug("headers", slug)
 
     with open(os.path.join(OUT_DIR, link), "w") as f:
         rendered = JINJA2_ENV.get_template(template).render(
@@ -155,6 +159,7 @@ def render(link, template, **metadata):
             permalink=f"{BASE_HREF}{link}",
             link=link,
             twitter_card=twitter_card,
+            header_image=header_image,
             **metadata,
         )
         print(rendered, file=f)

--- a/hashed-static/style.css
+++ b/hashed-static/style.css
@@ -6,6 +6,7 @@
     --link-glossary: var(--text);
     --border: #b1b4b6;
     --border-admonition: #730b0b;
+    --border-header: #730b0b;
     --main-title-fg: #ffffff;
     --main-title-bg: #730b0b;
     --thead-fg: #ffffff;
@@ -69,6 +70,12 @@ p {
     grid-auto-columns: 33%;
     grid-template-rows: min-content min-content;
     margin-top: 24px;
+}
+
+.post-header {
+    margin: 0 auto 24px auto;
+    display: block;
+    border: 1px solid var(--border-header);
 }
 
 #commento {


### PR DESCRIPTION
If a file `static/headers/{slug}.[png,jpg]` exists, it'll be displayed
at the top of the post.  These imaghes aren't necessarily the same as
the Twitter cards, because the Twitter cards might duplicate the title
or some image in the post, and so just look bad or be confusing.